### PR TITLE
Improve Cuboid && Add RowKey Encoder

### DIFF
--- a/src/core-cube/CMakeLists.txt
+++ b/src/core-cube/CMakeLists.txt
@@ -19,10 +19,12 @@ file(GLOB core-cube-src
   cube_instance.cpp
   cuboid/cuboid.cpp
   cuboid/cuboid_scheduler.cpp
+  cuboid/cuboid_scheduler_base.cpp
   cuboid/tree_cuboid_scheduler.cpp
   model/cube_desc.cpp
   model/dimension_desc.cpp
   model/row_key_col_desc.cpp
+  kv/row_key_encoder.cpp
   )
 
 husky_cache_variable(core-cube-src ${core-cube-src})

--- a/src/core-cube/cuboid/cuboid.hpp
+++ b/src/core-cube/cuboid/cuboid.hpp
@@ -14,32 +14,46 @@
 
 #pragma once
 
-#include <list>
 #include <memory>
 #include <vector>
+#include <set>
 
-#include "core-cube/cuboid/cuboid_scheduler.hpp"
-#include "core-cube/model/cube_desc.hpp"
 #include "core-metadata/metadata/model/tbl_col_ref.hpp"
 #include "utils/utils.hpp"
 
 namespace husky {
 namespace cube {
 
+class CuboidSchedulerBase;
+class CubeDesc;
+
 class Cuboid {
    public:
-    Cuboid(const std::shared_ptr<CubeDesc>& cube_desc, uint64_t original_id, uint64_t valid_id);
+    Cuboid(const std::shared_ptr<CubeDesc> & cube_desc, uint64_t original_id, uint64_t valid_id);
     ~Cuboid() {}
 
-   protected:
-    std::list<TblColRef*> translated_id_to_columns(uint64_t cuboid_id);
+    static Cuboid * find_cuboid(CuboidSchedulerBase * cuboid_scheduler, const std::set<TblColRef *> & dimensions);
+    static Cuboid * find_by_bytes_id(CuboidSchedulerBase * cuboid_scheduler, const std::vector<unsigned char> & cuboid_id);
+    static Cuboid * find_by_long_id(CuboidSchedulerBase * cuboid_scheduler, uint64_t cuboid_id);
+    static uint64_t to_cuboid_id(const std::shared_ptr<CubeDesc> & cube_desc, const std::set<TblColRef *> & dimensions);
+    static uint64_t get_base_cuboid_id(const std::shared_ptr<CubeDesc> & cube);
+    static Cuboid * get_base_cuboid(const std::shared_ptr<CubeDesc> & cube);
+
+    inline std::shared_ptr<CubeDesc> get_cube_desc() const { return cube_desc_;}
+    inline std::vector<TblColRef* > get_columns() const { return dimension_columns_; }
+    inline uint64_t get_id() const { return id_; }
+    inline std::vector<unsigned char> get_bytes() const { return id_bytes_; }
+    inline uint64_t get_input_id() const { return input_id_; }
+
+   protected: 
+    std::vector<TblColRef*> translated_id_to_columns(uint64_t cuboid_id);
 
    private:
     std::shared_ptr<CubeDesc> cube_desc_;
     uint64_t input_id_;
     uint64_t id_;
     std::vector<unsigned char> id_bytes_;
-    std::list<TblColRef*> dimension_columns_;
+    std::vector<TblColRef*> dimension_columns_;
 };
 
 }  // namespace cube

--- a/src/core-cube/cuboid/cuboid_scheduler_base.cpp
+++ b/src/core-cube/cuboid/cuboid_scheduler_base.cpp
@@ -1,24 +1,26 @@
-#include "core-cube/cuboid/CuboidScheduler.hpp"
+#include "core-cube/cuboid/cuboid_scheduler_base.hpp"
+
+#include "core-cube/model/cube_desc.hpp"
 
 namespace husky {
 namespace cube {
 
-const std::vector<std::vector<long> > CuboidScheduler::get_cuboids_by_layer() {
+std::vector<std::vector<uint64_t> > CuboidSchedulerBase::get_cuboids_by_layer() {
 	if (!cuboids_by_layer_.empty()) {
 		return cuboids_by_layer_;
 	}
 
-	int total_um = 0;
-	std::vector<long> base_cuboid_vec;
-	base_cuboid_vec.push_back(get_base_cuboid_id(cube_desc_));
+	int total_num = 0;
+	std::vector<uint64_t> base_cuboid_vec;
+	base_cuboid_vec.push_back(get_base_cuboid_id());
 	cuboids_by_layer_.push_back(base_cuboid_vec);
 	total_num++;
 
-	std::vector<long> last_layer = base_cuboid_vec;
+	std::vector<uint64_t> last_layer = base_cuboid_vec;
 	while(!last_layer.empty()) {
-		std::vector<long> new_layer;
+		std::vector<uint64_t> new_layer;
 		for(auto & parent : last_layer) {
-			const std::vector<long> spanning_cuboid = get_spanning_cuboid(parent);
+			const std::vector<uint64_t> spanning_cuboid = get_spanning_cuboid(parent);
 			new_layer.insert(new_layer.end(), spanning_cuboid.begin(), spanning_cuboid.end());
 		}
 		if(new_layer.empty()) { break; }
@@ -27,8 +29,8 @@ const std::vector<std::vector<long> > CuboidScheduler::get_cuboids_by_layer() {
 		last_layer = new_layer;
 	}
 
-	int size = get_all_cuboids_ids.size();
-	if(total_num != size) { return NULL; } // validate
+	int size = get_all_cuboid_ids().size();
+	// if(total_num != size) { return NULL; } // validate
 	return cuboids_by_layer_;
 }
 

--- a/src/core-cube/cuboid/cuboid_scheduler_base.cpp
+++ b/src/core-cube/cuboid/cuboid_scheduler_base.cpp
@@ -1,0 +1,36 @@
+#include "core-cube/cuboid/CuboidScheduler.hpp"
+
+namespace husky {
+namespace cube {
+
+const std::vector<std::vector<long> > CuboidScheduler::get_cuboids_by_layer() {
+	if (!cuboids_by_layer_.empty()) {
+		return cuboids_by_layer_;
+	}
+
+	int total_um = 0;
+	std::vector<long> base_cuboid_vec;
+	base_cuboid_vec.push_back(get_base_cuboid_id(cube_desc_));
+	cuboids_by_layer_.push_back(base_cuboid_vec);
+	total_num++;
+
+	std::vector<long> last_layer = base_cuboid_vec;
+	while(!last_layer.empty()) {
+		std::vector<long> new_layer;
+		for(auto & parent : last_layer) {
+			const std::vector<long> spanning_cuboid = get_spanning_cuboid(parent);
+			new_layer.insert(new_layer.end(), spanning_cuboid.begin(), spanning_cuboid.end());
+		}
+		if(new_layer.empty()) { break; }
+		cuboids_by_layer_.push_back(new_layer);
+		total_num += new_layer.size();
+		last_layer = new_layer;
+	}
+
+	int size = get_all_cuboids_ids.size();
+	if(total_num != size) { return NULL; } // validate
+	return cuboids_by_layer_;
+}
+
+}  // namespace cube
+}  // namespace husky

--- a/src/core-cube/cuboid/cuboid_scheduler_base.hpp
+++ b/src/core-cube/cuboid/cuboid_scheduler_base.hpp
@@ -19,15 +19,15 @@
 #include <string>
 #include <vector>
 
-// #include "core-cube/model/cube_desc.hpp"
+#include "core-cube/model/cube_desc.hpp"
 
 namespace husky {
 namespace cube {
 
 class CuboidSchedulerBase {
    public:
-    // CuboidScheduler(CubeDesc * cube_desc) { cube_desc_ = cube_desc}
-    CuboidSchedulerBase() {}  // for test
+    CuboidScheduler(std::shared_ptr<CubeDesc> cube_desc) { cube_desc_ = cube_desc}
+    // CuboidSchedulerBase() {}  // for test
     ~CuboidSchedulerBase() {}
 
     /** Returns all cuboids on the tree. */
@@ -44,11 +44,11 @@ class CuboidSchedulerBase {
 
     // ============================================================================
 
-    // inline get_base_cuboid_id() { return Cuboid.getBaseCuboidId(cube_desc_)}
+    inline get_base_cuboid_id() { return Cuboid.get_base_cuboid_id(cube_desc_)}
 
-    inline uint64_t get_base_cuboid_id() { return 31; }  // hard code; for test only
+    // inline uint64_t get_base_cuboid_id() { return 31; }  // hard code; for test only
 
-    // inline std::shared_ptr<CubeDesc> get_cube_desc() const { return cube_desc_;}
+    inline std::shared_ptr<CubeDesc> get_cube_desc() const { return cube_desc_;}
 
     /** Checks whether a cuboid is valid or not. */
     inline virtual bool is_valid(uint64_t request_cuboid) const {
@@ -60,18 +60,18 @@ class CuboidSchedulerBase {
  * Get cuboids by layer. It's built from pre-expanding tree.
  * return layered cuboids
  */
-    // const std::vector<std::vector<uint64_t> > get_cuboids_by_layer();
+    const std::vector<std::vector<uint64_t> > get_cuboids_by_layer();
 
     /**
  * Get cuboid level count except base cuboid
  */
-    // inline const int get_build_level() const { return get_cuboids_by_layer().size() - 1; }
+    inline const int get_build_level() const { return get_cuboids_by_layer().size() - 1; }
 
-    // protected:
-    //  std::shared_ptr<CubeDesc> cube_desc_;
+    protected:
+     std::shared_ptr<CubeDesc> cube_desc_;
 
-    // private:
-    //  std::vector<std::vector<uint64_t> > cuboids_by_layer_;
+    private:
+     std::vector<std::vector<uint64_t> > cuboids_by_layer_;
 };
 
 }  // namespace cube

--- a/src/core-cube/cuboid/cuboid_scheduler_base.hpp
+++ b/src/core-cube/cuboid/cuboid_scheduler_base.hpp
@@ -19,14 +19,16 @@
 #include <string>
 #include <vector>
 
-#include "core-cube/model/cube_desc.hpp"
+#include "core-cube/cuboid/cuboid.hpp"
 
 namespace husky {
 namespace cube {
 
+class CubeDesc;
+
 class CuboidSchedulerBase {
    public:
-    CuboidScheduler(std::shared_ptr<CubeDesc> cube_desc) { cube_desc_ = cube_desc}
+    CuboidSchedulerBase(std::shared_ptr<CubeDesc> cube_desc) { cube_desc_ = cube_desc; }
     // CuboidSchedulerBase() {}  // for test
     ~CuboidSchedulerBase() {}
 
@@ -44,7 +46,7 @@ class CuboidSchedulerBase {
 
     // ============================================================================
 
-    inline get_base_cuboid_id() { return Cuboid.get_base_cuboid_id(cube_desc_)}
+    inline uint64_t get_base_cuboid_id() { return Cuboid::get_base_cuboid_id(cube_desc_); }
 
     // inline uint64_t get_base_cuboid_id() { return 31; }  // hard code; for test only
 
@@ -60,12 +62,12 @@ class CuboidSchedulerBase {
  * Get cuboids by layer. It's built from pre-expanding tree.
  * return layered cuboids
  */
-    const std::vector<std::vector<uint64_t> > get_cuboids_by_layer();
+    std::vector<std::vector<uint64_t> > get_cuboids_by_layer();
 
     /**
  * Get cuboid level count except base cuboid
  */
-    inline const int get_build_level() const { return get_cuboids_by_layer().size() - 1; }
+    inline int get_build_level() { return get_cuboids_by_layer().size() - 1; }
 
     protected:
      std::shared_ptr<CubeDesc> cube_desc_;

--- a/src/core-cube/cuboid/tree_cuboid_scheduler.cpp
+++ b/src/core-cube/cuboid/tree_cuboid_scheduler.cpp
@@ -21,7 +21,7 @@
 
 #include "glog/logging.h"
 
-#include "core-cube/cuboid/cuboid_scheduler_base.hpp"
+#include "core-cube/model/cube_desc.hpp"
 
 namespace husky {
 namespace cube {

--- a/src/core-cube/cuboid/tree_cuboid_scheduler.hpp
+++ b/src/core-cube/cuboid/tree_cuboid_scheduler.hpp
@@ -17,16 +17,18 @@
 #include <algorithm>
 #include <map>
 #include <set>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-// #include "core-cube/model/cube_desc.hpp"
-// #include "core-cube/model/cuboid.hpp"
+#include "core-cube/cuboid/cuboid.hpp"
 #include "core-cube/cuboid/cuboid_scheduler_base.hpp"
 
 namespace husky {
 namespace cube {
+
+class CubeDesc;
 
 /** Do not consider aggregation group, simple cuboid scheduler */
 class TreeCuboidScheduler : public CuboidSchedulerBase {
@@ -78,18 +80,19 @@ class TreeCuboidScheduler : public CuboidSchedulerBase {
         std::map<uint64_t, TreeNode*> index_;
     };
 
-    // TreeCuboidScheduler(CubeDesc * cube_desc, std::vector<uint64_t> & all_cuboid_ids):CuboidScheduler(cube_desc) {}
-    explicit TreeCuboidScheduler(std::vector<uint64_t>& all_cuboid_ids)
-        : cuboid_tree_(CuboidTree::create_from_cuboids(all_cuboid_ids)) {}
-    TreeCuboidScheduler() : cuboid_tree_() {}
+    explicit TreeCuboidScheduler(std::shared_ptr<CubeDesc> cube_desc, std::vector<uint64_t> & all_cuboid_ids)
+            :CuboidSchedulerBase(cube_desc), cuboid_tree_(CuboidTree::create_from_cuboids(all_cuboid_ids)){}
+    // explicit TreeCuboidScheduler(std::vector<uint64_t>& all_cuboid_ids)
+        // : cuboid_tree_(CuboidTree::create_from_cuboids(all_cuboid_ids)) {}
+    TreeCuboidScheduler(std::shared_ptr<CubeDesc> cube_desc):CuboidSchedulerBase(cube_desc){}
     ~TreeCuboidScheduler() {}
 
     inline std::set<uint64_t> get_all_cuboid_ids() const override { return cuboid_tree_.get_all_cuboid_ids(); }
-    // inline int get_cuboid_count() const { return
-    // cuboid_tree_.get_cuboid_count(Cuboid.get_base_cuboid_id(cube_desc_))}
-    inline int get_cuboid_count() const override {
-        return cuboid_tree_.get_cuboid_count(31);
-    }  // hard code - [base cuboids id:] 11111(binary)
+    inline int get_cuboid_count() const { return
+    cuboid_tree_.get_cuboid_count(Cuboid::get_base_cuboid_id(cube_desc_)); }
+    // inline int get_cuboid_count() const override {
+    //     return cuboid_tree_.get_cuboid_count(31);
+    // }  // hard code - [base cuboids id:                                                                                           ] 11111(binary)
     inline std::vector<uint64_t> get_spanning_cuboid(uint64_t cuboid_id) const override {
         return cuboid_tree_.get_spanning_cuboid(cuboid_id);
     }

--- a/src/core-cube/kv/abstract_row_key_encoder.hpp
+++ b/src/core-cube/kv/abstract_row_key_encoder.hpp
@@ -1,0 +1,64 @@
+// Copyright 2018 Husky Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <map>
+
+#include "core-cube/cuboid/cuboid.hpp"
+
+namespace husky {
+namespace cube {
+
+class CubeDesc;
+class RowKeyEncoder;
+
+class AbstractRowKeyEncoder
+{
+public:
+	static const unsigned char DEFUAL_BLANK_BYTE;
+	// inline AbstractRowKeyEncoder * create_instance(const std::shared_ptr<CubeDesc> & cube_desc, Cuboid * cuboid) {
+	// 	return new RowKeyEncoder(cube_desc, cuboid);
+	// }
+	inline void set_blank_byte(unsigned char blank_byte) {
+		blank_byte_ = blank_byte;
+	}
+	inline uint64_t get_cuboid_id() const {
+		return cuboid_->get_id();
+	}
+	inline void set_cuboid_id(Cuboid * cuboid) {
+		cuboid_ = cuboid;
+	}
+
+	// virtual std::vector<unsigned char> creat_buf() = 0;
+	virtual void encode(const std::vector<unsigned char> & body_bytes, std::vector<unsigned char> & output_buf) = 0;
+	virtual std::vector<unsigned char> encode(std::map<TblColRef *, std::string> & value_map) = 0;
+	virtual std::vector<unsigned char> encode(std::vector<std::string> & values) = 0;
+
+protected:
+	unsigned char blank_byte_ = DEFUAL_BLANK_BYTE;
+	std::shared_ptr<CubeDesc> cube_desc_;
+	Cuboid * cuboid_;
+	AbstractRowKeyEncoder(const std::shared_ptr<CubeDesc> & cube_desc, Cuboid * cuboid):cube_desc_(cube_desc), cuboid_(cuboid) {}
+	~AbstractRowKeyEncoder() { delete cuboid_;}
+	
+};
+
+const unsigned char AbstractRowKeyEncoder::DEFUAL_BLANK_BYTE = 0xff;
+
+}  // namespace cube
+}  // namespace husky

--- a/src/core-cube/kv/row_key_constants.hpp
+++ b/src/core-cube/kv/row_key_constants.hpp
@@ -1,0 +1,29 @@
+// Copyright 2018 Husky Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace husky {
+namespace cube {
+
+class RowKeyConstants
+{
+public:
+	static const int ROWKEY_COL_DEFAULT_LENGTH = 256;
+	static const int ROWKEY_CUBOIDID_LENGTH = 8; // uint_64t
+	static const int ROWKEY_BUFFER_SIZE = 65 * 256; // a little more than 64 dimensions * 256 bytes each
+};
+
+}  // namespace cube
+}  // namespace husky

--- a/src/core-cube/kv/row_key_encoder.cpp
+++ b/src/core-cube/kv/row_key_encoder.cpp
@@ -1,0 +1,59 @@
+// Copyright 2018 Husky Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "core-cube/kv/row_key_encoder.hpp"
+#include "core-metadata/metadata/model/tbl_col_ref.hpp"
+
+namespace husky {
+namespace cube {
+
+RowKeyEncoder::RowKeyEncoder(const std::shared_ptr<CubeDesc> & cube_desc, Cuboid * cuboid): AbstractRowKeyEncoder(cube_desc, cuboid) {
+	for(auto const & column : cuboid->get_columns()) {
+		body_length_ += 4; // hard code! Should be different by dimension type (int, data, string, ...)
+	}
+}
+
+void RowKeyEncoder::encode(const std::vector<unsigned char> & body_bytes, std::vector<unsigned char> & output_buf) {
+	output_buf = body_bytes;
+	fill_header(output_buf);
+}
+
+std::vector<unsigned char> RowKeyEncoder::encode(std::map<TblColRef *, std::string> & value_map) {
+	std::vector<TblColRef *> columns = cuboid_->get_columns();
+	std::vector<std::string> values;
+	for(auto const & column : columns) {
+		values.push_back(value_map.find(column)->second);
+	}
+	return encode(values);
+}
+
+std::vector<unsigned char> RowKeyEncoder::encode(std::vector<std::string> & values) {
+	std::vector<unsigned char> bytes;
+	int offset = get_header_length();
+	std::vector<TblColRef *> columns = cuboid_->get_columns();
+
+	for(int i = 0; i < columns.size(); i++) {
+		TblColRef * column = columns[i];
+		// int colLength = colIO.getColumnLength(column); // hard code!
+		int col_length = 4;
+		fill_column_value(column, col_length, values[i], bytes, offset);
+		offset += col_length;
+	}
+
+	fill_header(bytes);
+	return bytes;
+}
+
+}  // namespace cube
+}  // namespace husky

--- a/src/core-cube/kv/row_key_encoder.hpp
+++ b/src/core-cube/kv/row_key_encoder.hpp
@@ -1,0 +1,71 @@
+// Copyright 2018 Husky Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "core-cube/kv/abstract_row_key_encoder.hpp"
+#include "core-cube/cuboid/cuboid.hpp"
+#include "core-cube/kv/row_key_constants.hpp"
+#include "core-metadata/dimension/dimension_encoding.hpp"
+#include "core-metadata/dimension/integer_dim_enc.hpp"
+
+#include <vector>
+#include <string>
+#include <map>
+
+namespace husky {
+namespace cube {
+
+class RowKeyEncoder: public AbstractRowKeyEncoder
+{
+public:
+	RowKeyEncoder(const std::shared_ptr<CubeDesc> & cube_desc, Cuboid * cuboid);
+	~RowKeyEncoder() {}
+	inline int get_header_length() const {
+		return hearder_length_;
+	}
+	inline int get_bytes_length() const {
+		return get_header_length() + body_length_;
+	}
+	inline void fill_header(std::vector<unsigned char> & bytes) {
+		int offset = 0; // for shard id(future use)
+		std::vector<unsigned char> cuboid_id_bytes = cuboid_->get_bytes();
+		bytes.insert(bytes.begin(), cuboid_id_bytes.begin(), cuboid_id_bytes.begin() + RowKeyConstants::ROWKEY_CUBOIDID_LENGTH);
+	}
+
+	/* override */
+	// inline std::vector<unsigned char> creat_buf() {
+	// 	std::vector<unsigned char> v;
+	// 	v.reserve(get_bytes_length());
+	// 	return v;
+	// }
+	void encode(const std::vector<unsigned char> & body_bytes, std::vector<unsigned char> & output_buf);
+	std::vector<unsigned char> encode(std::map<TblColRef *, std::string> & value_map);
+	std::vector<unsigned char> encode(std::vector<std::string> & values);
+
+private:
+	int body_length_ = 0;
+	// int uhc_off_set_ = -1; // it's a offset to the beginning of body (for shard id)
+	// int uhc_length_ = -1;
+	int hearder_length_;
+
+	void fill_column_value(TblColRef * column, int column_len, std::string & value_str, std::vector<unsigned char> & output_value, int output_offset) {
+		DimensionEncoding *  dimEnc = new IntegerDimEnc(4); // hard code! Should get DimEnc by column.
+		dimEnc->encode(value_str, output_value, output_offset);
+		delete dimEnc;
+	}
+};
+
+}  // namespace cube
+}  // namespace husky

--- a/src/core-cube/model/cube_desc.hpp
+++ b/src/core-cube/model/cube_desc.hpp
@@ -28,16 +28,18 @@
 #include "core-metadata/metadata/model/data_model_desc.hpp"
 #include "core-metadata/metadata/model/measure_desc.hpp"
 #include "core-metadata/metadata/model/parameter_desc.hpp"
+#include "core-cube/cuboid/cuboid_scheduler_base.hpp"
+#include "core-cube/cuboid/tree_cuboid_scheduler.hpp"
 
 namespace husky {
 namespace cube {
 
 using json = nlohmann::json;
 
-class CubeDesc {
+class CubeDesc:public std::enable_shared_from_this<CubeDesc> {
    public:
     explicit CubeDesc(const std::string& cubeDescJsonPath);
-    ~CubeDesc() {}
+    ~CubeDesc() { delete cuboid_scheduler_; }
 
     void init() {}  // Init cube desc
 
@@ -48,6 +50,11 @@ class CubeDesc {
     inline DataModelDesc& get_model() { return *model_; }
     inline std::shared_ptr<RowKeyDesc> get_row_key() { return row_key_; }
     inline std::list<AggregationGroup*> get_aggregation_groups() { return std::list<AggregationGroup*>(); }
+    inline CuboidSchedulerBase * get_initial_cuboid_scheduler() {
+        if(cuboid_scheduler_ == NULL)
+            cuboid_scheduler_ = new TreeCuboidScheduler(shared_from_this());
+        return cuboid_scheduler_;
+    } 
 
     /* Setters */
     inline void set_name(const std::string& name) { name_ = name; }
@@ -63,6 +70,7 @@ class CubeDesc {
     std::shared_ptr<RowKeyDesc> row_key_;
     std::vector<DimensionDesc> dimensions_;
     std::vector<MeasureDesc> measures_;
+    CuboidSchedulerBase * cuboid_scheduler_;
     int parent_forward_ = 3;
     uint64_t partition_date_start_ = 0L;
     uint64_t partition_date_end_ = 3153600000000L;

--- a/src/core-cube/model/row_key_col_desc.cpp
+++ b/src/core-cube/model/row_key_col_desc.cpp
@@ -32,7 +32,7 @@ void RowKeyColDesc::init(int index, const CubeDesc& cube_desc) {
     col_ref_ = cube_desc.get_model().find_column(column_);
     column_ = col_ref_->get_identity();
 
-    std::vector<std::string> encoding_params = DimensionDimEnc::parse_encoding_conf(encoding_);
+    std::vector<std::string> encoding_params = DimensionEncoding::parse_encoding_conf(encoding_);
     if (encoding_params.size() == 1) {
         // no args
         encoding_name_ = encoding_params[0];

--- a/src/core-cube/model/row_key_col_desc.hpp
+++ b/src/core-cube/model/row_key_col_desc.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-#include "core-metadata/dimension/dimension_dim_enc.hpp"
+#include "core-metadata/dimension/dimension_encoding.hpp"
 #include "core-metadata/metadata/model/tbl_col_ref.hpp"
 
 namespace husky {

--- a/src/core-metadata/dimension/dimension_encoding.hpp
+++ b/src/core-metadata/dimension/dimension_encoding.hpp
@@ -22,7 +22,7 @@
 namespace husky {
 namespace cube {
 
-class DimensionDimEnc {
+class DimensionEncoding {
    public:
     // it's convention that all 0xff means NULL
     static const unsigned char kNULL = (unsigned char) 0xff;

--- a/src/core-metadata/dimension/integer_dim_enc.hpp
+++ b/src/core-metadata/dimension/integer_dim_enc.hpp
@@ -17,13 +17,13 @@
 #include <string>
 #include <vector>
 
-#include "core-metadata/dimension/dimension_dim_enc.hpp"
+#include "core-metadata/dimension/dimension_encoding.hpp"
 #include "utils/utils.hpp"
 
 namespace husky {
 namespace cube {
 
-class IntegerDimEnc : public DimensionDimEnc {
+class IntegerDimEnc : public DimensionEncoding {
    public:
     explicit IntegerDimEnc(int len);
     ~IntegerDimEnc();

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -34,14 +34,14 @@ int bytes_to_int(const std::vector<unsigned char>& bytes) {
 }
 
 std::vector<unsigned char> long_to_bytes(uint64_t param_long) {
-    std::vector<unsigned char> array_of_bytes(4);
-    for (int i = 0; i < 4; ++i)
-        array_of_bytes[3 - i] = (int) ((param_long >> (i * 8)) & 0xFF);
+    std::vector<unsigned char> array_of_bytes(8);
+    for (int i = 0; i < 8; ++i)
+        array_of_bytes[7 - i] = (int) ((param_long >> (i * 8)) & 0xFF);
     return array_of_bytes;
 }
 
 uint64_t bytes_to_long(const std::vector<unsigned char>& bytes) {
-    return ((bytes[0] << 24) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3]);
+    return ((bytes[0] << 56) + (bytes[1] << 48) + (bytes[2] << 40) + (bytes[3] << 32) + (bytes[4] << 24) + + (bytes[5] << 16) + (bytes[6] << 8) + bytes[7]);
 }
 
 void write_long(uint64_t num, std::vector<unsigned char>& bytes, int offset, int size) {


### PR DESCRIPTION
What We Have Now:

- DataModelDesc: descibe all tables and dimensions (not only those used to build cube);

- CubeDesc: describe all tables, columns, measures and the scheduler used to build a cube;

- CuboidScheduler: an interface of cuboid scheduler, implemented by TreeCuboidScheduler;

- RowKeyEncoder: encode a row in a table in the form CuboidId_ColumnId1_ColumnId2_..., only support integer dimension encoding for now.

Future Work:

- [ ] Improve MeasureDesc to support Count, Max, Min and Sum 4 basic measures;

- [ ] Support String, Boolean, Float, Data and Time dimension encoders;

- [ ] Support more efficient cuboid scheduler considering aggregation group and black list;

- [ ] Integrate all the parts with husky to finish cubingByLayer